### PR TITLE
Add support for the Freenove ESP32-WROVER board

### DIFF
--- a/ESP32_PrusaConnectCam/Camera_cfg.h
+++ b/ESP32_PrusaConnectCam/Camera_cfg.h
@@ -12,6 +12,33 @@
 #ifndef _CAMERA_CFG_H_
 #define _CAMERA_CFG_H_
 
+// Uncomment this to switch from ESP32-Cam to ESP32-WROVER board.  You also have to do it in the
+// mcu_config.h file.
+// #define USE_ESP32_WROVER 1
+
+#if USE_ESP32_WROVER
+// OV2640 camera module pins (ESP32-WROVER)
+#define PWDN_GPIO_NUM     32      ///< Power down control pin
+#define RESET_GPIO_NUM    -1      ///< Reset control pin
+#define XCLK_GPIO_NUM     21      ///< External clock pin
+#define SIOD_GPIO_NUM     26      ///< SCCB: SI/O data pin
+#define SIOC_GPIO_NUM     27      ///< SCCB: SI/O control pin
+#define Y9_GPIO_NUM       35      ///< SCCB: Y9 pin
+#define Y8_GPIO_NUM       34      ///< SCCB: Y8 pin
+#define Y7_GPIO_NUM       39      ///< SCCB: Y7 pin
+#define Y6_GPIO_NUM       36      ///< SCCB: Y6 pin
+#define Y5_GPIO_NUM       19      ///< SCCB: Y5 pin
+#define Y4_GPIO_NUM       18      ///< SCCB: Y4 pin
+#define Y3_GPIO_NUM        5      ///< SCCB: Y3 pin
+#define Y2_GPIO_NUM        4      ///< SCCB: Y2 pin
+#define VSYNC_GPIO_NUM    25      ///< Vertical sync pin
+#define HREF_GPIO_NUM     23      ///< Line sync pin
+#define PCLK_GPIO_NUM     22      ///< Pixel clock pin
+
+#define FLASH_GPIO_NUM    32       ///< Flash control pin
+
+#else
+
 // OV2640 camera module pins (CAMERA_MODEL_AI_THINKER)
 #define PWDN_GPIO_NUM     32      ///< Power down control pin
 #define RESET_GPIO_NUM    -1      ///< Reset control pin
@@ -31,6 +58,8 @@
 #define PCLK_GPIO_NUM     22      ///< Pixel clock pin
 
 #define FLASH_GPIO_NUM    4       ///< Flash control pin
+
+#endif //USE_ESP32_WROVER
 
 #endif
 

--- a/ESP32_PrusaConnectCam/mcu_cfg.h
+++ b/ESP32_PrusaConnectCam/mcu_cfg.h
@@ -13,6 +13,10 @@
 #ifndef _MCU_CFG_H_
 #define _MCU_CFG_H_
 
+// Uncomment this to switch from ESP32-Cam to ESP32-WROVER board.  You also have to do it in the
+// Camera_cfg.h file.
+// #define USE_ESP32_WROVER 1
+
 /* ---------------- BASIC MCU CFG  --------------*/
 #define SW_VERSION                  "1.0.2-rc1"             ///< SW version
 #define SW_BUILD                    __DATE__ " " __TIME__   ///< build number
@@ -26,7 +30,13 @@
 #define REFRESH_INTERVAL_MAX        240                     ///< maximum refresh interval for sending photo to prusa connect [s]
 
 /* --------------- FLASH LED CFG  ---------------*/
+
+#if USE_ESP32_WROVER
+#define FLASH_GPIO_NUM              32                       ///< GPIO pin for light
+#else
 #define FLASH_GPIO_NUM              4                       ///< GPIO pin for light
+#endif //USE_ESP32_WROVER
+
 #define FLASH_OFF_STATUS            0                       ///< PWM intensity LED for OFF. 0-2^FLASH_PWM_RESOLUTION = 0-255
 #define FLASH_ON_STATUS             205                     ///< PWM intensity LED for ON. limitation to 80%. 2^FLASH_PWM_RESOLUTION * 0.8% = 204
 #define FLASH_PWM_FREQ              2000                    ///< frequency of pwm [240MHz / (100 prescale * pwm cycles)] = frequency
@@ -34,7 +44,12 @@
 #define FLASH_PWM_RESOLUTION        8                       ///< range 1-20bit. 8bit = 0-255 range
 
 /* -------------- STATUS LED CFG ----------------*/
+#if USE_ESP32_WROVER
+#define STATUS_LED_GPIO_NUM         2                      ///< GPIO pin for status LED
+#else
 #define STATUS_LED_GPIO_NUM         33                      ///< GPIO pin for status LED
+#endif //USE_ESP32_WROVER
+
 #define STATUS_LED_ENABLE           true                    ///< enable/disable status LED
 #define STATUS_LED_ON_DURATION      100                     ///< time for blink status LED when is module in the ON state [ms]
 #define STATUS_LED_WIFI_AP          400                     ///< time for blink status LED when is module in the AP mode [ms]

--- a/README.esp32_wrover.md
+++ b/README.esp32_wrover.md
@@ -1,0 +1,110 @@
+# Instructions to use the PrusaConnectCam with the FreeNove ESP32-WROVER 
+
+The Freenove ESP32-WROVER is an alternative option to the ESP32 Cam.  It is available at 
+[https://store.freenove.com/products/fnk0060](https://store.freenove.com/products/fnk0060) as
+well as places like Amazon and Ali Express.
+
+The main difference between this board and the ESP32-Cam is what pins are used.  The steps below is everything you need to do, starting from scratch, to connect to set up and program the board.  
+
+## Caveats
+
+As of this writing, I have not tested putting an LED flash on the board, since I have a separate
+lighting rig.  If someone confirms that it works, this README can be updated.
+
+## Install tools and set up the programming environment
+
+The FreeNove documentation for the board is excellent.  You can find it 
+[here](https://github.com/Freenove/Freenove_ESP32_WROVER_Board/tree/main), especially the 
+[PDF C Tutorial](https://github.com/Freenove/Freenove_ESP32_WROVER_Board/blob/main/C/C_Tutorial.pdf).  
+
+Make sure you do the following things from the FreeNove C tutorial.  Note that some of these things
+overlap with the main README instructions, but this is a full set of steps that works for a new
+board and a new environment.
+
+1. Page 5 - Install the CH340 Drivers if you don't already have them.
+2. Page 15 - Install the Arduino IDE.
+3. Page 18 - Set the Preferences > Additional Board Manager URLS and add 
+   `https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json`.
+4. Page 19 - Install the `esp32 tools` in the Arduino board manager
+5. Page 21 - Select the `esp32 Wrover Module` from the available boards 
+6. Page 48 - Format the included SD card.  This step is optional.  Formatting and
+   installing the card will allow logs to be written to the card.
+  
+Install the additional libraries as per the main readme: 
+[ here ](README.md#arduino_lib) <-- Note: For some reason, this link doesn't always take you 
+directly to the right place in the main readme.  If not, go to [README.md](README.md), find the 
+`What we need for functionality` section, and follow the link under 
+`Install the necessary libraries in the Arduino IDE here`.
+
+## Get the code and configure it for the WRover board
+
+Clone this repository.  In the Arduino editor, open the file 
+`ESP32_PrusaConnectCam/ESP32_PrusaConnectCam.ino`.
+
+You need to edit two files:
+
+- `ESP32_PrusaConnectCam/mcu_cfg.h`
+- `ESP32_PrusaConnectCam/Camera_cfg.h`
+
+In each file, uncomment the line:
+
+``` C++
+// #define USE_ESP32_WROVER 1
+```
+
+to make it:
+
+``` C++
+#define USE_ESP32_WROVER 1
+```
+
+This will change the pinouts from those that match the ESP32-Cam to those that match 
+the Freenove WRover board.  Here is a summary of the changes:
+
+- Change the GPIOs used to connect to the camera
+- Change the GPIO used for the status LED
+- Change the GPIO used for the optional LED flash to GPIO32
+
+## Program the board
+
+Note that the programming configuration is **NOT** the same as the main README.
+
+1. Install the 1GB flash card included with the Freenove kit into the SD card slot.  This is
+   optional, but doing so allows the board to write logs to it.
+2. Use a USB-C cable to plug the USB port on the board into your computer.
+3. Under the `Tools` menu in the Arduino IDE, check the following settings:
+   - `Board`:  `ESP32 WRover Module`
+   - `Port`: choose the COM port for the board
+   - `Erase All Flash before sketch upload` : Set this to `enable` **the first time you program the board**.  The set it to disable.  If you don't, it will erase the saved settings each time you program the board.
+   - `Flash Frequency`: `80 MHz`
+   - `Flash Mode`: `QIO`
+   - `Partition Scheme`: `Huge App (3MB No OTA/1MB SPIFFS)`
+   - `Upload Speed`: `115200`
+4. Hit the green Arrow button at the top left of the IDE to start programming the board.
+5. While the board is programming, go to `Tools > Serial Monitor` and set the serial monitor for `115200`.  
+6. Once the board is programmed, open the serial monitor tab.  You should see everything working.  If you see a message about a periodic reset, then this probably means the pin configuration is wrong.  In that case, double check that you   make sure you have uncommented the `#define USE_ESP32_WROVER 1` line in BOTH files mentioned above.
+
+## Connecting to the board
+
+The first time you program it, the board makes its own access point.  You can connect your computer to it, then visit `http://192.168.0.1` to set the WIFI name and password.
+
+Once it has WIFI credentials, the board will reset and you can find its IP address in your router's DHCP table.  I recommend reserving an IP for it in the router configuration so you can always find it.
+
+When you connect to the camera's IP from your local network, you can configure the camera parameters (image size, brightness, etc) and add the Prusa token for your Prusa Connect configuration.
+
+- Navigate to [connect.prusa3D.com](https://connect.prusa3D.com)
+- Open up the `printer details` page for the printer
+- Open up `Cameras` page.
+- Click `+ ADD NEW CAMERA`
+- You may have to refresh the page, but an "Unnamed Camera" option will appear.  
+- Copy the Token for the unnamed camera and input it on the camera's configuration page.
+
+If everything is working, you should see shots from your camera showing up in Prusa Connect.  If
+not, look at the serial monitor output to see if there are errors reported.
+
+## Installing the board in the enclosure
+
+There are several options to mount the board
+
+- [2 axis pivot for mounting on the enclosure wall](https://www.printables.com/model/876390)
+- [This remixed arm for mounting the camera on the Z axis carriage](https://www.printables.com/model/791446-freenove-esp32-wrover-cam-mount-prusa-mk3-mk4)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository includes source code and firmware releases for the ESP32-cam module programmed in the Arduino IDE
 
+To use this software with the Freenove ESP32-WROVER board, see [these instructions instead](README.esp32_wrover.md).
+
 This project uses other libraries. It is necessary to install them in the Arduino IDE.
 - App [Arduino IDE 2.3.2](https://www.arduino.cc/en/software)
 - MCU support [ESP32 2.0.16](https://github.com/espressif/arduino-esp32)


### PR DESCRIPTION
This adds support for the Freenove ESP32-WROVER board.  Everything in the original firmware works fine except that the GPIO must be remapped.  So there are #if statements to make this change in two files.  I also wrote a detailed readme for building and installing the code on the board.

The main goal here is to have the ESP32-WROVER benefit from bug fixes and improvements.  Putting #if switch statements around the GPIO definitions doesn't seem that elegant or scalable, but I could not find a better strategy anywhere.  Also, it seems like the Arduino IDE doesn't have a way to add compiler flags, so the #define for the flag has to be set in each file. If there's a different, preferred way of doing this, I'm happy to rework the code and update the PR.