### PR TITLE
✨(webpage): Added button to start the live-stream

### DIFF
--- a/webpage/index.html
+++ b/webpage/index.html
@@ -46,6 +46,7 @@
 				<button class="btn" onclick="actionButton('/action_capture',true,'')">Refresh Snapshot</button> <br><br>
 				<button class="btn" onclick="actionButton('/action_send',false,'')">Send snapshot</button><br><br><br>
 				<button class="btn" onclick="window.open('saved-photo.jpg')">Download snapshot</button><br><br>
+				<button class="btn" onclick="window.open('stream.mjpg')">Start stream</button><br><br>
 			</article>
 		</div>
 	</section>


### PR DESCRIPTION
Added a button on the webpage below `Download snapshot` to open the live-stream URL, improving accessibility.

![2024-05-28 11_27_54-Prusa ESP32-cam und 2 weitere Seiten - Geschäftlich – Microsoft​ Edge](https://github.com/prusa3d/Prusa-Firmware-ESP32-Cam/assets/352704/c820cfeb-6b4f-45f8-96f8-db2c2514f98b)

Also see issues #31 and #17 