### PR TITLE
set wifi password input field as a "password" type

### DIFF
--- a/webpage/page_wifi.html
+++ b/webpage/page_wifi.html
@@ -39,7 +39,7 @@
 			<table>
 				<tr><td class="w1">Connect to Wi-Fi network</td></tr>
 				<tr><td class="w2"  align="right">Wi-Fi network name (SSID) </td><td><input type="text" name="wifi_ssid" id=wifi_ssid_id ></td></tr>
-				<tr><td class="w2"  align="right">Password </td><td><input type="text" name="wifi_pass" id=wifi_pass_id></td></tr>
+				<tr><td class="w2"  align="right">Password </td><td><input type="password" name="wifi_pass" id=wifi_pass_id></td></tr>
 				<tr><td></td><td align="center"><button class="btn_save_w" onclick="setWifi(document.getElementById('wifi_ssid_id').value, document.getElementById('wifi_pass_id').value)">Save & Connect</button></td></tr>
 			</table>
 		</td><td></td></tr>


### PR DESCRIPTION
thanks for this nice software!!

this PR just is just a quick fix of the input type for the wifi password field because the autocorrection on smartphone was *really annoying* when i configured my cam