### PR TITLE
Fix various typos in READMEs

### DIFF
--- a/doc/AI_Thinker-ESP32-cam/README.md
+++ b/doc/AI_Thinker-ESP32-cam/README.md
@@ -18,7 +18,7 @@ What we need for functionality
 <a name="esp32"></a>
 ## ESP32-CAM AI-thinker board 
 
-Basic informations:
+Basic information:
 - Low cost version
 - FLASH LED on the board
 - Option connecting external FLASH LED
@@ -32,7 +32,7 @@ It's a few dollars board with **ESP32** MCU and Camera. It's necessary to buy a 
 
 <img src="esp32-cam.jpg" width=30% height=30%>
 
-In the following picture, we can see the **ESP32-CAM** board and the programator for the board. 
+In the following picture, we can see the **ESP32-CAM** board and the programmer for the board. 
 
 <img src="esp32_and_prog.jpg" width=30% height=30%>
 

--- a/doc/ESP32-S3-CAM/README.md
+++ b/doc/ESP32-S3-CAM/README.md
@@ -17,11 +17,11 @@ What we need for functionality
 <a name="esp32"></a>
 ##  ESP32-S3-CAM
 
-Basic informations:
+Basic information:
 - Onboard RGB LED (most likely ws2812b)
 - Option connecting external FLASH LED
 - Micro SD card slot
-- Internal or External WiFi antena
+- Internal or External WiFi antenna
 - 16MB FLASH and 8MB external PSRAM
 - 520 KB SRAM
 - Excellent WiFi signal

--- a/doc/ESP32-S3-EYE-22/README.md
+++ b/doc/ESP32-S3-EYE-22/README.md
@@ -16,7 +16,7 @@ What we need for functionality
 <a name="esp32"></a>
 ## ESP32-S3-EYE 2.2
 
-Basic informations:
+Basic information:
 - On the board missing LED for flash
 - Option connecting external FLASH LED
 - Micro SD card slot

--- a/doc/ESP32-Wrover-dev/README.md
+++ b/doc/ESP32-Wrover-dev/README.md
@@ -17,7 +17,7 @@ What we need for functionality
 <a name="esp32"></a>
 ## Freenove ESP32-Wrover-CAM
 
-Basic informations:
+Basic information:
 - On the board missing LED for flash
 - Option connecting external FLASH LED
 - Missing micro SD card slot

--- a/doc/XIAO_ESP32S3/README.md
+++ b/doc/XIAO_ESP32S3/README.md
@@ -18,10 +18,10 @@ What we need for functionality
 <a name="esp32"></a>
 ##  XIAO ESP32S3 sense board 
 
-Basic informations:
+Basic information:
 - Option connecting external FLASH LED
 - Micro SD card slot
-- External WiFi antena
+- External WiFi antenna
 - 8MB FLASH and 8MB external PSRAM
 - 520 KB SRAM
 - Small dimension 21 x 17.5 x 15mm (with expansion board)


### PR DESCRIPTION
Fixed typos:

- antena -> antenna
- programator -> programmer
- informations -> information