### PR TITLE
Fix broken link in README.md for ESP32-S3-Wroom

### DIFF
--- a/doc/Freenove ESP32-S3-Wroom/README.md
+++ b/doc/Freenove ESP32-S3-Wroom/README.md
@@ -2,7 +2,7 @@
 
 What we need for functionality
 - Freenove ESP32-S3 WROOM board with OV2640 camera module [ here ](#esp32)
-- Supported camera modules [here](cam_modules)
+- Supported camera modules [here](#cam_modules)
 - How to flash binary files to board from Linux/MAC/Windows [ here ](#flash_fw)
 - How to compile software in the Arduino IDE [ here ](#arduino_cfg)
 - How to reset the configuration to factory settings [here](#factory_cfg)


### PR DESCRIPTION
Fix broken link to the cam modules section by adding the missing "#" in the readme for Freenove ESP32-S3-Wroom