### PR TITLE
Remove Content-Length header from chunked response

### DIFF
--- a/ESP32_PrusaConnectCam/WebServer.cpp
+++ b/ESP32_PrusaConnectCam/WebServer.cpp
@@ -64,7 +64,6 @@ void Server_InitWebServer() {
         }
         return len;
       });
-      response->addHeader("Content-Length", String(total_len));
       request->send(response);
 
     } else {
@@ -1350,3 +1349,4 @@ String Server_TranslateBoolToString(bool i_data) {
 }
 
 /* EOF */
+


### PR DESCRIPTION
HTTP does not allow Content-Length header to be set when Transfer-Encoding is present (https://greenbytes.de/tech/webdav/rfc2616.html#rfc.section.4.4)

When chunked, Transfer-Encoding is set. This causes issues, for example when adding the camera to HomeAssistant, since it causes an error in the http library. A visible result of this error is that HomeAssistant doesn't show the saved-photo.jpeg (http://esp32cam-name.local/saved-photo.jpg) in a dashboard view,

This commit removes the Content-Length header in this case. Tested, and the fix seems to allow showing the saved-photo.jpeg in the dashboard in HomeAssistant.